### PR TITLE
Removed the line about aeza.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,6 @@ Fow query to CF-DNS using Unbound. This is some type of DNS forwarding.
 
 Recomendation VPS Hosting with 10% Discount: 	[VDSina.ru](https://vdsina.ru/?partner=rwmhc7jbcg)
 
-#### I do not recommend the VPS service: aeza.net
-
 ## Autors:
 
 👤 ** Alexey **


### PR DESCRIPTION
Hello! I read on the forum that your software does not work on aeza.net. Since I am their customer, I decided to check the functionality myself. Here are my test results:

wg-easy Web:
- HEL: https://ibb.co/VMghD8W
- VIE: https://ibb.co/gFYZVtX

ADG Home Web:
- HEL: https://ibb.co/D58zqLy
- VIE: https://ibb.co/sV4mJBg

ADG Home DNS:
- HEL: https://ibb.co/fxgMHKN
- VIE: https://ibb.co/KzR6DZ7

Unbound DNS:
- HEL: https://ibb.co/Yhr5Njz
- VIE: https://ibb.co/8NnH6JT

So I think that aeza.net is unfairly labeled as a non-working hosting provider here. This PR removes that line. 

Thank you for your attention.